### PR TITLE
Unifying btn styling on edit idea and new post page

### DIFF
--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -10,3 +10,51 @@
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15); // stronger shadow
   }
 }
+
+.icon-button-container {
+  height: 100%
+}
+
+.icon-button {            // icon button styling on New/Edit/Post idea pages
+  height: 100%;
+  position: sticky;
+  top: 100px;
+  margin-top: 20px;
+  padding: 16px 16px;
+  align-items: center;
+  justify-content: center;
+  display: flex;
+
+  i{
+    font-size: 48px;
+  }
+
+  button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+}
+
+.icon-button-description {
+  position: absolute;
+  left: 100px;
+  top: 16px;
+  opacity: 0;
+  transition: 0.2s linear;
+
+  &:hover {
+    opacity: 1;
+  }
+
+  // quick transition when finished hovering
+  &:not(:hover) {
+    transition: 0.2s ease-out;
+  }
+}
+
+
+.icon-button:hover .icon-button-description {
+  opacity: 1;
+}

--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -15,8 +15,9 @@
 .icon-button-container {
   height: 100%;
   position: sticky;
-  top: 100px;
-  margin-top: 20px;
+  top: 130px;
+  margin-top: 8px;
+  gap: 16px;
 
   .icon-button {
     height: 100%;

--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -20,9 +20,7 @@
   gap: 16px;
 
   .icon-button {
-    height: 100%;
     padding: 16px 16px;
-    align-items: center;
     justify-content: center;
     display: flex;
 

--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -11,50 +11,49 @@
   }
 }
 
+// icon button styling on New/Edit/Post idea pages
 .icon-button-container {
-  height: 100%
-}
-
-.icon-button {            // icon button styling on New/Edit/Post idea pages
   height: 100%;
   position: sticky;
   top: 100px;
   margin-top: 20px;
-  padding: 16px 16px;
-  align-items: center;
-  justify-content: center;
-  display: flex;
 
-  i{
-    font-size: 48px;
-  }
-
-  button {
-    display: flex;
+  .icon-button {
+    height: 100%;
+    padding: 16px 16px;
     align-items: center;
     justify-content: center;
+    display: flex;
+
+    i{
+      font-size: 48px;
+    }
+
+    button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
   }
 
-}
+  .icon-button-description {
+    position: absolute;
+    left: 100px;
+    top: 16px;
+    opacity: 0;
+    transition: 0.2s linear;
 
-.icon-button-description {
-  position: absolute;
-  left: 100px;
-  top: 16px;
-  opacity: 0;
-  transition: 0.2s linear;
+    &:hover {
+      opacity: 1;
+    }
 
-  &:hover {
+    // quick transition when finished hovering
+    &:not(:hover) {
+      transition: 0.2s ease-out;
+    }
+  }
+
+  .icon-button:hover .icon-button-description {
     opacity: 1;
   }
-
-  // quick transition when finished hovering
-  &:not(:hover) {
-    transition: 0.2s ease-out;
-  }
-}
-
-
-.icon-button:hover .icon-button-description {
-  opacity: 1;
 }

--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -23,6 +23,7 @@
     padding: 16px 16px;
     justify-content: center;
     display: flex;
+    position: relative;
 
     i{
       font-size: 48px;
@@ -38,7 +39,7 @@
   .icon-button-description {
     position: absolute;
     left: 100px;
-    top: 16px;
+    top: 20px;
     opacity: 0;
     transition: 0.2s linear;
 

--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -18,12 +18,15 @@
   top: 130px;
   margin-top: 8px;
   gap: 16px;
+  min-width: 130px;
 
   .icon-button {
     padding: 16px 16px;
     justify-content: center;
     display: flex;
     position: relative;
+    width: 65%;
+    aspect-ratio: 1 / 1;
 
     i{
       font-size: 48px;
@@ -38,8 +41,8 @@
 
   .icon-button-description {
     position: absolute;
-    left: 100px;
-    top: 20px;
+    left: 90px;
+    top: 16px;
     opacity: 0;
     transition: 0.2s linear;
 

--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -253,8 +253,7 @@
   border-radius: 16px;
   background-color: $pinksheet;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.05);
-  margin-left: 24px;
-  margin-right: 24px;
+  margin: 8px;
 }
 
 .new-form-header {

--- a/app/views/ideas/edit.html.erb
+++ b/app/views/ideas/edit.html.erb
@@ -18,17 +18,17 @@
   </div>
 
   <%# Add submit button %>
-  <div class="flex-column edit-form-buttons">
-    <div class="edit-form-button">
+  <div class="flex-column icon-button-container">
+    <div class="icon-button btn btn-primary">
       <%= form_idea.button type: "submit", name: "pressed_button", value: "save" do %>
         <i class='fa-solid fa-floppy-disk'></i>
-        <span class="edit-form-button-description">Save</span>
+        <span class="icon-button-description">Save</span>
       <% end %>
     </div>
-    <div class="edit-form-button">
+    <div class="icon-button btn btn-primary">
       <%= form_idea.button type: "submit", name: "pressed_button", value: "share" do %>
-        <i class='fa-solid fa-share-from-square'></i>
-        <span class="edit-form-button-description">Share</span>
+        <i class="fa-solid fa-arrow-up-right-from-square"></i>
+        <span class="icon-button-description">Share</span>
       <% end %>
     </div>
   </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -70,11 +70,12 @@
 
     </div>
 
-    <!-- Instead of the feedback form, displaying the Submit button in the same column -->
-    <div class="btn btn-primary flex-column post-edit-form-buttons">
-        <div>
-        <%= form_post.button "<i class='fa-solid fa-paper-plane', style='font-size: 48px;' ></i> ".html_safe, type: "submit", class: "new-button" %>
+    <div class="flex-column icon-button-container">
+      <div class="icon-button btn btn-primary">
+        <%= form_post.button type: "submit" do %>
+          <i class='fa-solid fa-paper-plane'></i>
+          <span class="icon-button-description">Publish</span>
+        <% end %>
       </div>
     </div>
-
-      <% end %>
+    <% end %>


### PR DESCRIPTION
Had to make some slightly janky changes here so that the button hover effects wouldnt stretch off the side of the screen, nothing insane but just had to increase the size of the container and stuff. Also copied this styling on the new post page, and reduce the margins there so that it matches the page before